### PR TITLE
✨ feat: implement assistant and thread services with seed functionali…

### DIFF
--- a/apps/brain/src/index.ts
+++ b/apps/brain/src/index.ts
@@ -1,4 +1,4 @@
-import { auth, brainEnvConfig } from '@chad-chat/brain-service'
+import { auth, brainEnvConfig, seed } from '@chad-chat/brain-service'
 import { sentry } from '@hono/sentry'
 import { trpcServer } from '@hono/trpc-server'
 import { createBunHonoWSHandler } from '@valkyrie-resistance/trpc-ws-hono-bun-adapter'
@@ -62,6 +62,11 @@ if (brainEnvConfig.app.sentryDsn) {
 if (!brainEnvConfig.app.dev) {
   app.use('*', serveStatic({ root: './public' }))
   app.use('*', serveStatic({ root: './public', path: 'index.html' }))
+}
+
+// Seed Marvin if in development
+if (brainEnvConfig.app.dev) {
+  seed().catch(console.error)
 }
 
 // Export the app

--- a/apps/brain/src/lib/trpc.ts
+++ b/apps/brain/src/lib/trpc.ts
@@ -53,7 +53,7 @@ export const createWsContext = async (
 export const publicProcedure = t.procedure
 export const protectedProcedure = t.procedure.use(async ({ next, ctx }) => {
   const { user, session } = ctx
-  if (!session) {
+  if (!session || !user) {
     throw new TRPCError({ code: 'UNAUTHORIZED' })
   }
   return next({ ctx: { user, session } })

--- a/apps/brain/src/routes/threads/mutations.ts
+++ b/apps/brain/src/routes/threads/mutations.ts
@@ -1,3 +1,11 @@
+import {
+  AssistantQueries,
+  LLMModelQueries,
+  MessageMutations,
+  ThreadMutations,
+  ThreadQueries,
+} from '@chad-chat/brain-repository'
+import { TRPCError } from '@trpc/server'
 import z from 'zod'
 import { protectedProcedure, router } from '../../lib/trpc'
 
@@ -7,15 +15,103 @@ export const threadsMutations = router({
       z.object({
         title: z.string(),
         description: z.string(),
+        assistantId: z.string(),
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      return {
-        thread: {
-          id: '1',
-          title: input.title,
-          description: input.description,
-        },
+      if (!ctx.user) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'User must be authenticated to create threads',
+        })
       }
+
+      const assistant =
+        (await AssistantQueries.getAssistantById(input.assistantId, ctx.user.id)) ||
+        (await AssistantQueries.getPublicAssistantById(input.assistantId))
+
+      if (!assistant) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Assistant not found or you do not have access to it',
+        })
+      }
+
+      const thread = await ThreadMutations.createThread({
+        title: input.title,
+        userId: ctx.user.id,
+        assistantId: input.assistantId,
+      })
+
+      return { thread }
+    }),
+
+  createMessage: protectedProcedure
+    .input(
+      z.object({
+        body: z.string(),
+        threadId: z.string(),
+        llmModelId: z.string(),
+        assistantId: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'User must be authenticated to create messages',
+        })
+      }
+
+      const thread = await ThreadQueries.getThreadById(input.threadId, ctx.user.id)
+
+      if (!thread) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Thread not found or you do not have access to it',
+        })
+      }
+
+      const assistant =
+        (await AssistantQueries.getAssistantById(input.assistantId, ctx.user.id)) ||
+        (await AssistantQueries.getPublicAssistantById(input.assistantId))
+
+      if (!assistant) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Assistant not found or you do not have access to it',
+        })
+      }
+
+      const model = await LLMModelQueries.getModelById(input.llmModelId)
+
+      if (!model) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'LLM model not found',
+        })
+      }
+
+      const message = await MessageMutations.createMessage({
+        threadId: input.threadId,
+        content: input.body,
+        role: 'USER',
+        metadata: {
+          assistantId: input.assistantId,
+          llmModelId: input.llmModelId,
+        },
+      })
+
+      const messageWithUser = await MessageMutations.addUserToMessage(message.id, ctx.user.id)
+      const messageWithModel = await MessageMutations.addModelToMessage(
+        messageWithUser.id,
+        input.llmModelId,
+      )
+      const messageWithAssistant = await MessageMutations.addAssistantToMessage(
+        messageWithModel.id,
+        input.assistantId,
+      )
+
+      return { message: messageWithAssistant }
     }),
 })

--- a/apps/brain/src/routes/threads/queries.ts
+++ b/apps/brain/src/routes/threads/queries.ts
@@ -1,15 +1,17 @@
+import { ThreadSearchSchemaInput } from '@chad-chat/brain-domain'
+import { assistantService, threadService } from '@chad-chat/brain-service'
 import { protectedProcedure, router } from '../../lib/trpc'
 
 export const threadsQueries = router({
-  getThreads: protectedProcedure.query(async ({ ctx }) => {
-    return {
-      threads: [
-        {
-          id: '1',
-          title: 'Thread 1',
-          description: 'Thread 1 description',
-        },
-      ],
-    }
+  searchThreads: protectedProcedure.input(ThreadSearchSchemaInput).query(async ({ ctx, input }) => {
+    return threadService.searchThreads(ctx.user.id, input)
+  }),
+
+  getSidebarThreads: protectedProcedure.query(async ({ ctx }) => {
+    return threadService.getSidebarThreads(ctx.user.id)
+  }),
+
+  getAssistants: protectedProcedure.query(async ({ ctx }) => {
+    return assistantService.getAssistants(ctx.user.id)
   }),
 })

--- a/packages/brain/domain/src/entities/thread-query.ts
+++ b/packages/brain/domain/src/entities/thread-query.ts
@@ -8,6 +8,10 @@ export const ThreadCursorSchema = z.object({
   id: ThreadIdSchema,
 })
 
+export const ThreadSearchSchemaInput = z.object({
+  query: z.string(),
+})
+
 export const ThreadListInputSchema = z.object({
   limit: z.number().int().positive(),
   cursor: ThreadCursorSchema.optional(),

--- a/packages/brain/repository/src/index.ts
+++ b/packages/brain/repository/src/index.ts
@@ -1,3 +1,4 @@
 export { prisma } from './prisma/client'
 export * from '../generated/prisma'
 export * from './prisma/queries'
+export * from './prisma/mutations'

--- a/packages/brain/repository/src/prisma/migrations/20250618053958_unique_constraints/migration.sql
+++ b/packages/brain/repository/src/prisma/migrations/20250618053958_unique_constraints/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[id,threadId]` on the table `message` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[id,userId]` on the table `thread` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "message_id_threadId_key" ON "message"("id", "threadId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "thread_id_userId_key" ON "thread"("id", "userId");

--- a/packages/brain/repository/src/prisma/mutations/index.ts
+++ b/packages/brain/repository/src/prisma/mutations/index.ts
@@ -1,3 +1,4 @@
 export * as ThreadMutations from './threads'
 export * as MessageMutations from './messages'
 export * as AssistantMutations from './assistants'
+export * as SharedChatsMutations from './shared-chats'

--- a/packages/brain/repository/src/prisma/queries/index.ts
+++ b/packages/brain/repository/src/prisma/queries/index.ts
@@ -1,3 +1,4 @@
-export * from './threads'
-export * from './messages'
-export * from './assistants'
+export * as AssistantQueries from './assistants'
+export * as MessageQueries from './messages'
+export * as ThreadQueries from './threads'
+export * as LLMModelQueries from './llm-models'

--- a/packages/brain/repository/src/prisma/queries/llm-models.ts
+++ b/packages/brain/repository/src/prisma/queries/llm-models.ts
@@ -1,0 +1,62 @@
+import { type LLMModel, LLMModelIdSchema, LLMModelSchema } from '@chad-chat/brain-domain'
+import { prisma } from '../client'
+
+export async function getModelById(modelId: string): Promise<LLMModel | null> {
+  const validatedId = LLMModelIdSchema.parse(modelId)
+
+  const model = await prisma.lLMModel.findUnique({
+    where: {
+      id: validatedId,
+    },
+    select: {
+      id: true,
+      name: true,
+      provider: true,
+      displayName: true,
+      description: true,
+      isActive: true,
+      isDefault: true,
+    },
+  })
+
+  return model ? LLMModelSchema.parse(model) : null
+}
+
+export async function getActiveModels(): Promise<LLMModel[]> {
+  const models = await prisma.lLMModel.findMany({
+    where: {
+      isActive: true,
+    },
+    select: {
+      id: true,
+      name: true,
+      provider: true,
+      displayName: true,
+      description: true,
+      isActive: true,
+      isDefault: true,
+    },
+  })
+
+  return models.map((model) => LLMModelSchema.parse(model))
+}
+
+export async function getDefaultModels(): Promise<LLMModel[]> {
+  const models = await prisma.lLMModel.findMany({
+    where: {
+      isDefault: true,
+      isActive: true,
+    },
+    select: {
+      id: true,
+      name: true,
+      provider: true,
+      displayName: true,
+      description: true,
+      isActive: true,
+      isDefault: true,
+    },
+  })
+
+  return models.map((model) => LLMModelSchema.parse(model))
+}

--- a/packages/brain/repository/src/prisma/queries/messages.ts
+++ b/packages/brain/repository/src/prisma/queries/messages.ts
@@ -6,12 +6,7 @@ import {
   MessageSchema,
 } from '@chad-chat/brain-domain'
 import { ThreadIdSchema } from '@chad-chat/brain-domain'
-import type { Prisma } from '../../../generated/prisma'
 import { prisma } from '../client'
-
-type MessageWithRelations = Prisma.MessageGetPayload<{
-  include: { thread: true }
-}>
 
 export async function getAllMessages(
   threadId: string,
@@ -23,7 +18,7 @@ export async function getAllMessages(
   const { limit, cursor } = MessageListInputSchema.parse(input)
   const validatedThreadId = ThreadIdSchema.parse(threadId)
 
-  const messages = (await prisma.message.findMany({
+  const messages = await prisma.message.findMany({
     where: {
       threadId: validatedThreadId,
     },
@@ -39,7 +34,7 @@ export async function getAllMessages(
           id: cursor.id,
         }
       : undefined,
-  })) as MessageWithRelations[]
+  })
 
   const nextCursor =
     messages.length > limit
@@ -59,7 +54,7 @@ export async function getMessageById(messageId: string, threadId: string): Promi
   const validatedMessageId = MessageIdSchema.parse(messageId)
   const validatedThreadId = ThreadIdSchema.parse(threadId)
 
-  const message = (await prisma.message.findUnique({
+  const message = await prisma.message.findUnique({
     where: {
       messageCompoundId: {
         id: validatedMessageId,
@@ -69,7 +64,7 @@ export async function getMessageById(messageId: string, threadId: string): Promi
     include: {
       thread: true,
     },
-  })) as MessageWithRelations | null
+  })
 
   return message ? MessageSchema.parse(message) : null
 }
@@ -98,7 +93,7 @@ export async function getMessagesUpToId(
     return []
   }
 
-  const messages = (await prisma.message.findMany({
+  const messages = await prisma.message.findMany({
     where: {
       threadId: validatedThreadId,
       createdAt: {
@@ -109,7 +104,7 @@ export async function getMessagesUpToId(
       thread: true,
     },
     orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
-  })) as MessageWithRelations[]
+  })
 
   return messages.map((message) => MessageSchema.parse(message))
 }

--- a/packages/brain/repository/src/prisma/queries/shared-chats.ts
+++ b/packages/brain/repository/src/prisma/queries/shared-chats.ts
@@ -8,12 +8,7 @@ import {
   SharedChatSchema,
   UserIdSchema,
 } from '@chad-chat/brain-domain'
-import type { Prisma } from '../../../generated/prisma'
 import { prisma } from '../client'
-
-type SharedChatWithRelations = Prisma.SharedChatGetPayload<{
-  include: { thread: true; sharedBy: true }
-}>
 
 export async function getAllSharedChats(input: SharedChatListInput): Promise<{
   sharedChats: SharedChat[]
@@ -21,7 +16,7 @@ export async function getAllSharedChats(input: SharedChatListInput): Promise<{
 }> {
   const { limit, cursor, userId } = SharedChatListInputSchema.parse(input)
 
-  const sharedChats = (await prisma.sharedChat.findMany({
+  const sharedChats = await prisma.sharedChat.findMany({
     where: {
       sharedById: userId,
     },
@@ -38,7 +33,7 @@ export async function getAllSharedChats(input: SharedChatListInput): Promise<{
           id: cursor.id,
         }
       : undefined,
-  })) as SharedChatWithRelations[]
+  })
 
   const nextCursor =
     sharedChats.length > limit
@@ -57,7 +52,7 @@ export async function getAllSharedChats(input: SharedChatListInput): Promise<{
 export async function getSharedChatById(sharedChatId: string): Promise<SharedChat | null> {
   const validatedId = SharedChatIdSchema.parse(sharedChatId)
 
-  const sharedChat = (await prisma.sharedChat.findUnique({
+  const sharedChat = await prisma.sharedChat.findUnique({
     where: {
       id: validatedId,
     },
@@ -65,7 +60,7 @@ export async function getSharedChatById(sharedChatId: string): Promise<SharedCha
       thread: true,
       sharedBy: true,
     },
-  })) as SharedChatWithRelations | null
+  })
 
   return sharedChat ? SharedChatSchema.parse(sharedChat) : null
 }
@@ -77,7 +72,7 @@ export async function getSharedChatByUserId(
   const validatedId = SharedChatIdSchema.parse(sharedChatId)
   const validatedUserId = UserIdSchema.parse(userId)
 
-  const sharedChat = (await prisma.sharedChat.findFirst({
+  const sharedChat = await prisma.sharedChat.findFirst({
     where: {
       id: validatedId,
       sharedById: validatedUserId,
@@ -86,7 +81,7 @@ export async function getSharedChatByUserId(
       thread: true,
       sharedBy: true,
     },
-  })) as SharedChatWithRelations | null
+  })
 
   return sharedChat ? SharedChatSchema.parse(sharedChat) : null
 }
@@ -96,7 +91,7 @@ export async function getSharedChatByShareId(
 ): Promise<SharedChat | null> {
   const { shareId } = SharedChatByShareIdInputSchema.parse(input)
 
-  const sharedChat = (await prisma.sharedChat.findUnique({
+  const sharedChat = await prisma.sharedChat.findUnique({
     where: {
       shareId,
     },
@@ -104,7 +99,7 @@ export async function getSharedChatByShareId(
       thread: true,
       sharedBy: true,
     },
-  })) as SharedChatWithRelations | null
+  })
 
   return sharedChat ? SharedChatSchema.parse(sharedChat) : null
 }

--- a/packages/brain/service/package.json
+++ b/packages/brain/service/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./seeders": "./src/seeders/seed.ts"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -12,6 +13,7 @@
   },
   "dependencies": {
     "better-auth": "^1.2.9",
-    "@chad-chat/brain-domain": "workspace:*"
+    "@chad-chat/brain-domain": "workspace:*",
+    "@chad-chat/brain-repository": "workspace:*"
   }
 }

--- a/packages/brain/service/src/assistants/queries.ts
+++ b/packages/brain/service/src/assistants/queries.ts
@@ -1,0 +1,7 @@
+import { AssistantQueries } from '@chad-chat/brain-repository'
+
+export const assistantService = {
+  getAssistants: async (userId: string) => {
+    return AssistantQueries.getAssistants(userId)
+  },
+}

--- a/packages/brain/service/src/index.ts
+++ b/packages/brain/service/src/index.ts
@@ -1,2 +1,5 @@
 export * from './config/auth'
 export * from './config/env'
+export * from './seeders'
+export * from './threads/queries'
+export * from './assistants/queries'

--- a/packages/brain/service/src/seeders/index.ts
+++ b/packages/brain/service/src/seeders/index.ts
@@ -1,0 +1,1 @@
+export * from './seed'

--- a/packages/brain/service/src/seeders/seed.ts
+++ b/packages/brain/service/src/seeders/seed.ts
@@ -1,0 +1,42 @@
+import { PrismaClient } from '@chad-chat/brain-repository'
+
+const prisma = new PrismaClient()
+
+export const seed = async () => {
+  try {
+    await prisma.assistant.deleteMany({
+      where: {
+        name: 'Marvin',
+      },
+    })
+
+    const marvinPromptPath = new URL(
+      '../../../domain/src/values/prompts/marvin.md',
+      import.meta.url,
+    )
+    const marvinPrompt = await Bun.file(marvinPromptPath).text()
+
+    const marvin = await prisma.assistant.create({
+      data: {
+        name: 'Marvin',
+        description:
+          'A deeply depressed hyper-intelligent AI companion assistant with a cynical and sarcastic personality.',
+        systemPrompt: marvinPrompt,
+        isPublic: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    })
+
+    console.log('Assistant created:', {
+      id: marvin.id,
+      name: marvin.name,
+      description: marvin.description,
+    })
+  } catch (error) {
+    console.error('Error creating assistant:', error)
+    throw error
+  } finally {
+    await prisma.$disconnect()
+  }
+}

--- a/packages/brain/service/src/threads/queries.ts
+++ b/packages/brain/service/src/threads/queries.ts
@@ -1,0 +1,15 @@
+import type { ThreadSearchSchemaInput } from '@chad-chat/brain-domain'
+import { ThreadQueries } from '@chad-chat/brain-repository'
+import type { z } from 'zod'
+
+const defaultLimit = 20
+
+export const threadService = {
+  searchThreads: async (userId: string, input: z.infer<typeof ThreadSearchSchemaInput>) => {
+    return ThreadQueries.searchThreadsByName(userId, input.query, defaultLimit)
+  },
+
+  getSidebarThreads: async (userId: string) => {
+    return ThreadQueries.getSidebarThreads(userId)
+  },
+}


### PR DESCRIPTION
This pull request introduces several updates to enhance functionality, improve query efficiency, and enforce stricter validation across the codebase. The most significant changes include the addition of new thread and message mutation procedures, updates to assistant-related queries, and the introduction of unique database constraints to ensure data integrity.

### Backend Functionality Enhancements:
* Added new mutation procedures for creating threads and messages in `apps/brain/src/routes/threads/mutations.ts`, including validation for user authentication, assistant existence, and LLM model availability. These mutations now interact with the database to create threads and messages dynamically.

* Introduced new query procedures in `apps/brain/src/routes/threads/queries.ts` for searching threads, fetching sidebar threads, and retrieving assistants, leveraging services for cleaner and more modular logic.

### Database and Query Improvements:
* Added unique constraints to the `message` and `thread` tables in `packages/brain/repository/src/prisma/migrations/20250618053958_unique_constraints/migration.sql` to prevent duplicate entries and ensure data consistency.

* Simplified assistant-related queries in `packages/brain/repository/src/prisma/queries/assistants.ts` by removing unnecessary type casting and redundant relations, and added a new method to fetch both user-specific and public assistants. [[1]](diffhunk://#diff-cdb4ea33b9fe3ddf6a4f0b2b14762c0557b5ccf08df27a1a445a2fe5692dc104L11-L30) [[2]](diffhunk://#diff-cdb4ea33b9fe3ddf6a4f0b2b14762c0557b5ccf08df27a1a445a2fe5692dc104L163-R197)

* Introduced new LLM model queries in `packages/brain/repository/src/prisma/queries/llm-models.ts` to fetch models by ID, as well as active and default models, facilitating better integration with the thread and message mutations.

### Validation and Error Handling:
* Strengthened validation in `apps/brain/src/lib/trpc.ts` by ensuring both `session` and `user` are present before allowing access to protected procedures.

* Added schema validation for thread search inputs in `packages/brain/domain/src/entities/thread-query.ts` to ensure query parameters are well-formed.

### Codebase Organization:
* Refactored exports in `packages/brain/repository/src/index.ts` and `packages/brain/repository/src/prisma/queries/index.ts` to use namespaced exports, improving readability and maintainability. [[1]](diffhunk://#diff-a666d555767a1bf6b0a383b5f9b80b7d41710b1f4000841268225753a3449134R4) [[2]](diffhunk://#diff-883ba7721be55ad670493a3d1464d8c737f10681592496569dc804eb52926b8cL1-R4)

These changes collectively improve the robustness, scalability, and maintainability of the codebase while introducing new features for thread and message management.…ty and enhanced queries

## Summary by Sourcery

Implement thread and message management by adding new mutations and queries with robust validation, introduce LLM model support and seeding logic, enforce database constraints, and reorganize code with service layers and namespaced exports.

New Features:
- Add mutations for thread creation with authentication and assistant checks
- Add mutations for message creation with validation of thread, assistant, and LLM model
- Introduce LLM model queries to fetch models by ID, active, and default status
- Add seeding functionality to provision a default assistant in development
- Expose and integrate thread and assistant service methods in TRPC routes

Enhancements:
- Enforce stricter session and user validation in protected procedures
- Add schema validation for thread searches
- Apply unique constraints on thread and message tables to ensure data integrity
- Refactor Prisma query and mutation exports to a namespaced structure
- Simplify assistant queries and consolidate retrieval of user-specific and public assistants
- Modularize thread and assistant logic into dedicated service layers

Build:
- Update package exports in brain-service to include seeders and in repository to include mutations